### PR TITLE
feat(dir/helm): update configurations for v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.5.2 (2025-11-20)
+## v0.5.2 (2025-11-24)
 
 ### Updated
 - Bump DIR components to v0.5.2 (from v0.4.0)
@@ -11,6 +11,9 @@
 - Update trust domain to `example.org`
 
 ### Added
+- SQLite PVC configuration support for persistent database storage
+- Deployment strategy configuration (Recreate) to prevent lock conflicts
+- Automatic `/tmp` emptyDir mounting when `readOnlyRootFilesystem` is enabled
 - Resource limits (DIR: 250m/512Mi requests, Zot: 100m/256Mi requests)
 - Pod Security Standards (seccomp, runAsNonRoot, drop capabilities)
 - Rate limiting (50 RPS for local Kind)
@@ -23,7 +26,8 @@
 - Explicit user ID (65532)
 
 ### Documentation
-- Optional PVC persistence guide
+- Database PVC persistence guide for production
+- Deployment strategy requirements for PVC usage
 - ExternalSecrets pattern documentation
 - Production deployment considerations
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ For production deployment, consider these enhancements:
 | Feature | This Example (Kind) | Production |
 |---------|---------------------|------------|
 | **Storage** | emptyDir (ephemeral) | PVCs (persistent) |
+| **Deployment Strategy** | Recreate (default) | Recreate (required with PVCs) |
 | **Credentials** | Hardcoded in values.yaml | ExternalSecrets + Vault |
 | **Resources** | 250m/512Mi | 500m-2000m / 1-4Gi |
 | **Ingress** | NodePort (local) | Ingress + TLS |
@@ -148,6 +149,7 @@ For production deployment, consider these enhancements:
 - Enable PVCs for routing datastore and database (v0.5.2+)
 - Prevents data loss across pod restarts
 - See `pvc.create` and `database.pvc.enabled` in values.yaml
+- **IMPORTANT**: When using PVCs, set `strategy.type: Recreate` to prevent database lock conflicts
 
 **Secure Credential Management**:
 - Use ExternalSecrets Operator with Vault instead of hardcoded secrets

--- a/applications/dir/dev/values.yaml
+++ b/applications/dir/dev/values.yaml
@@ -189,6 +189,19 @@ apiserver:
   #     accessMode: ReadWriteOnce
   #
   # Benefits: Database persists across restarts, faster recovery, enables readOnlyRootFilesystem
+  
+  # Deployment strategy (NEW in v0.5.2)
+  # Default: Recreate (prevents database lock conflicts during updates)
+  # This is the chart default - explicit here for documentation
+  #
+  # IMPORTANT: When using PVCs (routing or database), Recreate strategy is REQUIRED
+  # to prevent BadgerDB/SQLite lock conflicts during rolling updates.
+  # With emptyDir (this example), RollingUpdate would work but Recreate is safer.
+  #
+  # strategy:
+  #   type: Recreate  # Terminates old pod before starting new one
+  #
+  # Trade-off: Brief downtime (10-15 seconds) during updates for clean deployments
 
   # Pod Security Standards (NEW in v0.5.2 example)
   # Enhanced security for production-grade deployments


### PR DESCRIPTION
- Update dir-staging documentation and configuration for v0.5.2 deployment strategy and storage features
- Documents the new v0.5.2 deployment strategy configuration (Recreate) required when using PVCs to prevent BadgerDB/SQLite lock conflicts during rolling updates. 
- Updates CHANGELOG.md to include missing v0.5.2 features (SQLite PVC support, automatic /tmp mounting, deployment strategy), adds critical warnings in README.md for production PVC deployments, and enhances the comparison table to clearly show deployment strategy differences between Kind and production environments.