### PR TITLE
chore: bump DIR components to v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.5.5 (2025-12-03)
+
+### Updated
+- Bump DIR components to v0.5.5 (from v0.5.2)
+- Enable SPIFFE CSI driver for reliable identity injection (`useCSIDriver: true`)
+- Add OASF API validation configuration (lax mode by default)
+
+### Added
+- SPIFFE CSI driver configuration for dir-apiserver and dir-admin
+  - Eliminates "certificate contains no URI SAN" authentication failures
+  - Provides synchronous workload registration (no race conditions)
+- OASF validation lax mode (`oasf_api_validation_strict_mode: false`)
+  - Allows validation warnings for non-standard OASF modules
+  - Rejects actual validation errors
+
+### Changed
+- SPIRE integration now uses CSI ephemeral volumes instead of hostPath
+  - More secure (avoids hostPath in workload containers)
+  - More reliable (synchronous identity injection)
+
+---
+
 ## v0.5.2 (2025-11-24)
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ The manifests are organized into two main sections:
 - `projectapps/`: Contains Argo CD application definitions.
 
 The project will deploy the following components:
-- `applications/dir` - AGNTCY Directory server with storage backend (v0.5.2)
-- `applications/dir-admin` - AGNTCY Directory Admin CLI client (v0.5.2)
-- `applications/spire*` - SPIRE stack for identity and federation
+- `applications/dir` - AGNTCY Directory server with storage backend (v0.5.5)
+- `applications/dir-admin` - AGNTCY Directory Admin CLI client (v0.5.5)
+- `applications/spire*` - SPIRE stack for identity and federation (with SPIFFE CSI driver)
 
 **NOTE**: This is not a production-ready deployment. It is
 provided as-is for demonstration and testing purposes.
 
-**Latest Version**: v0.5.2 - See [CHANGELOG.md](CHANGELOG.md) for what's new.
+**Latest Version**: v0.5.5 - See [CHANGELOG.md](CHANGELOG.md) for what's new.
 
 ## Onboarding
 
@@ -132,6 +132,7 @@ For production deployment, consider these enhancements:
 
 | Feature | This Example (Kind) | Production |
 |---------|---------------------|------------|
+| **SPIFFE CSI Driver** | ✅ Enabled (v0.5.5+) | ✅ Enabled |
 | **Storage** | emptyDir (ephemeral) | PVCs (persistent) |
 | **Deployment Strategy** | Recreate (default) | Recreate (required with PVCs) |
 | **Credentials** | Hardcoded in values.yaml | ExternalSecrets + Vault |
@@ -144,6 +145,12 @@ For production deployment, consider these enhancements:
 **This configuration is optimized for local testing. For production, enable the optional features documented below.**
 
 ### Key Production Features
+
+**SPIFFE CSI Driver** (v0.5.5+):
+- Enabled by default via `spire.useCSIDriver: true`
+- Provides synchronous workload identity injection
+- Eliminates authentication race conditions ("certificate contains no URI SAN" errors)
+- More secure than hostPath mounts in workload containers
 
 **Persistent Storage**:
 - Enable PVCs for routing datastore and database (v0.5.2+)

--- a/applications/dir-admin/dev/config.json
+++ b/applications/dir-admin/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "ghcr.io",
   "chart_name": "agntcy/dir/helm-charts/dirctl",
-  "chart_version": "v0.5.2"
+  "chart_version": "v0.5.5"
 }

--- a/applications/dir-admin/dev/values.yaml
+++ b/applications/dir-admin/dev/values.yaml
@@ -10,14 +10,16 @@ global:
 # Image config
 image:
   repository: ghcr.io/agntcy/dir-ctl
-  tag: v0.5.2
+  tag: v0.5.5
   pullPolicy: IfNotPresent
   pullSecrets: []
 
 # SPIRE configuration
+# Chart v0.5.3+ defaults to SPIFFE CSI driver for reliable identity injection
 spire:
   enabled: true
   trustDomain: example.org
+  useCSIDriver: true  # Eliminates "certificate contains no URI SAN" auth failures
 
 # Additional environment variables (applied to all cronjobs)
 env:

--- a/applications/dir/dev/config.json
+++ b/applications/dir/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "ghcr.io",
   "chart_name": "agntcy/dir/helm-charts/dir",
-  "chart_version": "v0.5.2"
+  "chart_version": "v0.5.5"
 }

--- a/applications/dir/dev/values.yaml
+++ b/applications/dir/dev/values.yaml
@@ -5,7 +5,7 @@ apiserver:
 
   image:
     repository: ghcr.io/agntcy/dir-apiserver
-    tag: v0.5.2
+    tag: v0.5.5
     pullPolicy: IfNotPresent
     pullSecrets: []
   
@@ -45,13 +45,20 @@ apiserver:
     externalTrafficPolicy: Local
 
   # SPIRE configuration
+  # Chart v0.5.3+ defaults to SPIFFE CSI driver for reliable identity injection
   spire:
     enabled: true
     trustDomain: example.org
+    useCSIDriver: true  # Eliminates "certificate contains no URI SAN" auth failures
 
   # API server configuration
   config:
     listen_address: "0.0.0.0:8888"
+
+    # OASF API validation configuration (NEW in v0.5.5)
+    # Lax mode allows validation warnings (non-standard modules) but rejects actual errors
+    # Set to true for strict validation that rejects all warnings
+    oasf_api_validation_strict_mode: false
 
     # Authentication settings (handles identity verification)
     # Supports both X.509 (X.509-SVID) and JWT (JWT-SVID) authentication


### PR DESCRIPTION
## Description

Updates the dir-staging example deployment from v0.5.2 to v0.5.5.

### Changes

- **Version bump**: DIR apiserver and CLI to v0.5.5
- **SPIFFE CSI driver**: Enable `useCSIDriver: true` for both `dir` and `dir-admin`
  - Provides synchronous workload identity injection
  - Eliminates "certificate contains no URI SAN" authentication failures
- **OASF validation**: Add `oasf_api_validation_strict_mode: false` (lax mode)
  - Allows validation warnings for non-standard OASF modules
- **Documentation**: Updated README and CHANGELOG

### Compatibility

- ✅ Kind clusters (Kubernetes 1.16+)
- ✅ Minikube clusters
- ✅ SPIRE Helm chart v0.27.0 (includes CSI driver by default)

## Type of Change

- [x] Other: Version bump with new features

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass