### PR TITLE
add(dell): federation bundle configuration for agntcy-research-dell.com

### DIFF
--- a/onboarding/federation/agntcy-research-dell.com.yaml
+++ b/onboarding/federation/agntcy-research-dell.com.yaml
@@ -1,0 +1,6 @@
+# dir-staging/onboarding/federation/agntcy-research-dell.com.yaml
+className: dir-spire
+trustDomain: agntcy-research-dell.com
+bundleEndpointURL: https://spire.agntcy-research-dell.com
+bundleEndpointProfile:
+  type: https_web


### PR DESCRIPTION
# Description

Adding federation bundle information for Dell AGNTCY Directory node hosted on GCP for testing purposes.

This is an initial testing exercise, future urls and domains may change.
