### PR TITLE
Add mitdataworksai.com federation for MBTA Transit Coversational Intelligence

### DIFF
--- a/onboarding/federation/mitdataworksai.com.yaml
+++ b/onboarding/federation/mitdataworksai.com.yaml
@@ -1,0 +1,5 @@
+className: dir-spire
+trustDomain: mitdataworksai.com
+bundleEndpointURL: https://spire.mitdataworksai.com
+bundleEndpointProfile:
+  type: https_web


### PR DESCRIPTION
# Description

This PR adds federation configuration for mitdataworksai.com, enabling the MBTA Transit Conversational Intelligence - Directory instance to federate with the production Directory at prod.ads.outshift.io.

The MBTA Transit Conversational Intelligence is a multi-agent AI system for Massachusetts Bay Transportation Authority transit intelligence, built as a collaborative project between Northeastern University, Akamai Technologies, MIT, and Cisco.

Our Directory instance is deployed on Akamai Cloud (LKE) with SPIRE using the https_web federation profile (Let's Encrypt). The federation file adds our trust domain (mitdataworksai.com) and SPIRE bundle endpoint (https://spire.mitdataworksai.com).

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/dir-staging/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
