### PR TITLE
onboarding/federation: add meetloyd.com

### DIFF
--- a/onboarding/federation/meetloyd.com.yaml
+++ b/onboarding/federation/meetloyd.com.yaml
@@ -1,0 +1,5 @@
+className: dir-spire
+trustDomain: meetloyd.com
+bundleEndpointURL: https://spire.meetloyd.com
+bundleEndpointProfile:
+  type: https_web


### PR DESCRIPTION
## Federation request: meetloyd.com

Registering MeetLoyd's SPIRE trust domain for bidirectional federation with the AGNTCY Directory, per @tibor-kircsi's Slack guidance (2026-04-13).

### Profile
`https_web` — bundle endpoint uses Let's Encrypt ACME (TLS-ALPN-01) served directly by our SPIRE server.

### Trust domain
`meetloyd.com`

### Bundle endpoint
`https://spire.meetloyd.com` — publicly accessible, HTTP/2, returns bundle JSON. Verified live.

### Contact
Laurent Beaumois — laurent@meetloyd.com
