### PR TITLE
feat: prepare for Dir release v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ The manifests are organized into two main sections:
 - `projectapps/`: Contains Argo CD application definitions.
 
 The project will deploy the following components:
-- `applications/dir` - AGNTCY Directory server with storage backend (v1.2.0)
+- `applications/dir` - AGNTCY Directory server with storage backend (v1.3.0)
+- `applications/oidc-gateway` - optional standalone OIDC gateway for external `dirctl` / SDK / automation access (v0.1.1)
 - `applications/spire*` - SPIRE stack for identity and federation (with SPIFFE CSI driver)
 
 **NOTE**: This is not a production-ready deployment. It is
 provided as-is for demonstration and testing purposes.
 
-**Latest Version**: v1.2.0 - See [CHANGELOG.md](CHANGELOG.md) for what's new.
+**Latest Version**: v1.3.0 - See [CHANGELOG.md](CHANGELOG.md) for what's new.
 
 ## Getting Started
 
@@ -49,13 +50,19 @@ Choose your path based on your goal:
 1. Deploy your Directory instance (see [Getting Started](https://docs.agntcy.org/dir/getting-started/))
 2. Setup federation (see [Client Onboarding Guide](onboarding/README.md) after deployment)
 
+As of `dir` `v1.3.0`, the Helm chart provides a default DHT bootstrap address for the public testbed. In most cases you should leave bootstrap-peer settings unset in your values unless you intentionally need to override that default.
+
 ---
 
-## Optional OIDC Authentication Add-On
+## Optional OIDC Authentication Gateway
 
-The default Directory deployment in this repository uses SPIFFE/SPIRE-oriented authentication that works well for in-cluster workloads. If you also want to support `dirctl`, SDKs, or automation running **outside** the cluster, enable the optional OIDC add-on in `applications/dir/dev/values.yaml`.
+The default Directory deployment in this repository uses SPIFFE/SPIRE-oriented authentication that works well for in-cluster workloads. If you also want to support `dirctl`, SDKs, or automation running **outside** the cluster, deploy the standalone `oidc-gateway` application alongside `dir`.
 
-This add-on puts an Envoy gateway in front of Directory:
+The public gateway chart lives in the dedicated repository:
+
+- [agntcy/oidc-gateway](https://github.com/agntcy/oidc-gateway)
+
+This gateway puts Envoy in front of Directory:
 
 1. A remote client gets an OIDC token from your identity provider.
 2. Envoy validates the JWT using the configured issuer and JWKS settings.
@@ -64,25 +71,24 @@ This add-on puts an Envoy gateway in front of Directory:
 
 ### When to Use It
 
-Use the OIDC add-on when:
+Use the OIDC gateway when:
 
 - You want remote `dirctl` access from a laptop or workstation outside the cluster
 - You want a human login flow backed by Dex
 - You want GitHub Actions or other external automation to call Directory with OIDC tokens
 
-Keep it disabled if you only need in-cluster, SPIFFE-based access.
+You do not need this gateway if you only use in-cluster, SPIFFE-based access.
 
 ### What to Configure
 
-The staging example now includes a fully commented, opt-in OIDC block in `applications/dir/dev/values.yaml`. The main settings are:
+The staging example now includes a separate `oidc-gateway` app under `applications/oidc-gateway/dev/`. The main settings are:
 
-- `apiserver.envoyAuthz.enabled`: installs the optional Envoy/ext-authz add-on
-- `apiserver.envoy-authz.envoy.backend.*`: points Envoy at the internal Directory service
-- `apiserver.envoy-authz.envoy.oidc.dex.*`: configures Dex as the human/user OIDC issuer
-- `apiserver.envoy-authz.envoy.oidc.github.*`: configures GitHub Actions OIDC for automation
-- `apiserver.envoy-authz.authServer.oidc.issuers`: maps issuers to principal types such as `user` or `github`
-- `apiserver.envoy-authz.authServer.oidc.roles`: maps users, clients, or workflows to allowed gRPC methods
-- `apiserver.envoy-authz.ingress.*`: exposes the Envoy gateway for external access over gRPC
+- `envoy.backend.*`: points Envoy at the internal Directory service
+- `envoy.oidc.issuers[]`: configures user-facing OIDC issuers such as Dex
+- `envoy.oidc.github.*`: configures GitHub Actions OIDC for automation
+- `authServer.oidc.issuers`: maps issuers to principal types such as `user` or `github`
+- `authServer.oidc.roles`: maps users, clients, or workflows to allowed gRPC methods
+- `ingress.*`: exposes the Envoy gateway for external access over gRPC
 
 ### Dex and Remote Clients
 
@@ -90,16 +96,16 @@ If you want interactive user login, configure Dex in `applications/dex/dev/value
 
 - `config.issuer` matches the public URL where Dex is reachable
 - your GitHub OAuth app credentials are supplied through a Kubernetes Secret
-- the Dex issuer values in `applications/dex/dev/values.yaml` and `applications/dir/dev/values.yaml` match
+- the Dex issuer values in `applications/dex/dev/values.yaml` and `applications/oidc-gateway/dev/values.yaml` match
 
-Enabling Dex by itself is not enough for remote Directory access. Remote clients also need the Envoy/ext-authz add-on enabled so their OIDC tokens can be validated before requests reach Directory.
+Enabling Dex by itself is not enough for remote Directory access. Remote clients also need the standalone `oidc-gateway` deployed so their OIDC tokens can be validated before requests reach Directory.
 
 ### Canonical Field Reference
 
 The staging values file is a user-facing example. For the complete public source of truth for all supported fields, see:
 
-- `agntcy/dir/install/charts/dir/apiserver/values.yaml`
-- `agntcy/dir/install/charts/envoy-authz/values.yaml`
+- `agntcy/dir/install/charts/dir/values.yaml`
+- `agntcy/oidc-gateway/install/charts/oidc-gateway/values.yaml`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The manifests are organized into two main sections:
 
 The project will deploy the following components:
 - `applications/dir` - AGNTCY Directory server with storage backend (v1.3.0)
-- `applications/oidc-gateway` - optional standalone OIDC gateway for external `dirctl` / SDK / automation access (v0.1.1)
+- `applications/oidc-gateway` - optional standalone OIDC/SPIFFE gateway for external `dirctl` / SDK / automation access (v1.0.0)
 - `applications/spire*` - SPIRE stack for identity and federation (with SPIFFE CSI driver)
 
 **NOTE**: This is not a production-ready deployment. It is
@@ -54,7 +54,7 @@ As of `dir` `v1.3.0`, the Helm chart provides a default DHT bootstrap address fo
 
 ---
 
-## Optional OIDC Authentication Gateway
+## Optional OIDC/SPIFFE Authentication Gateway
 
 The default Directory deployment in this repository uses SPIFFE/SPIRE-oriented authentication that works well for in-cluster workloads. If you also want to support `dirctl`, SDKs, or automation running **outside** the cluster, deploy the standalone `oidc-gateway` application alongside `dir`.
 
@@ -64,10 +64,10 @@ The public gateway chart lives in the dedicated repository:
 
 This gateway puts Envoy in front of Directory:
 
-1. A remote client gets an OIDC token from your identity provider.
-2. Envoy validates the JWT using the configured issuer and JWKS settings.
-3. The ext-authz service maps token claims to roles and allowed gRPC methods.
-4. Only authorized requests are forwarded to the internal Directory apiserver.
+1. A remote client presents an OIDC JWT, SPIFFE JWT-SVID, or SPIFFE X.509-SVID.
+2. Envoy validates bearer JWTs with `jwt_authn` or downstream SPIFFE mTLS when enabled.
+3. The ext-authz service normalizes the caller to a canonical principal and checks allowed gRPC methods.
+4. Only authorized requests are forwarded to the internal Directory apiserver with the configured principal header.
 
 ### When to Use It
 
@@ -84,10 +84,11 @@ You do not need this gateway if you only use in-cluster, SPIFFE-based access.
 The staging example now includes a separate `oidc-gateway` app under `applications/oidc-gateway/dev/`. The main settings are:
 
 - `envoy.backend.*`: points Envoy at the internal Directory service
-- `envoy.oidc.issuers[]`: configures user-facing OIDC issuers such as Dex
+- `envoy.oidc.issuers[]`: configures Envoy `jwt_authn` providers and JWKS lookup for bearer-token validation
 - `envoy.oidc.github.*`: configures GitHub Actions OIDC for automation
-- `authServer.oidc.issuers`: maps issuers to principal types such as `user` or `github`
-- `authServer.oidc.roles`: maps users, clients, or workflows to allowed gRPC methods
+- `authServer.oidc.issuers`: maps verified token issuers to stable provider keys such as `dex` or `github`
+- `authServer.oidc.headers.authPrincipal`: sets the canonical principal header forwarded to Directory (`x-auth-principal` by default)
+- `authServer.oidc.roles`: maps canonical principals such as `oidc:dex:alice`, `oidc:github:repo:...`, or `spiffe:spiffe://...` to allowed gRPC methods
 - `ingress.*`: exposes the Envoy gateway for external access over gRPC
 
 ### Dex and Remote Clients

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,7 @@ version: '3'
 vars:
   VULN_SCAN_CHARTS:
     - applications/dir/dev
+    - applications/oidc-gateway/dev
     - applications/spire/dev
     - applications/dex/dev
     - applications/dex-credentials/dev

--- a/applications/dex/dev/values.yaml
+++ b/applications/dex/dev/values.yaml
@@ -19,8 +19,8 @@ config:
   # Public URL where Dex is exposed (must match ingress/DNS)
   # Keep this value aligned with:
   # - connectors[].config.redirectURI (same hostname + /callback)
-  # - applications/dir/dev/values.yaml -> apiserver.envoy-authz.envoy.oidc.dex.issuer
-  # - applications/dir/dev/values.yaml -> apiserver.envoy-authz.authServer.oidc.issuers[].provider
+  # - applications/oidc-gateway/dev/values.yaml -> envoy.oidc.issuers[].issuer
+  # - applications/oidc-gateway/dev/values.yaml -> authServer.oidc.issuers[].provider
   issuer: https://dex.example.com
 
   storage:
@@ -44,7 +44,7 @@ config:
       name: Directory CLI
       # Public client for browser/device login flows from developer machines.
       # The CLI is expected to obtain a Dex token first, then call the Directory
-      # OIDC gateway exposed by applications/dir/dev/values.yaml.
+      # OIDC gateway exposed by applications/oidc-gateway/dev/values.yaml.
       public: true
       redirectURIs:
         # Local browser callback used by interactive login flows.

--- a/applications/dir/dev/config.json
+++ b/applications/dir/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "ghcr.io",
   "chart_name": "agntcy/dir/helm-charts/dir",
-  "chart_version": "v1.2.0"
+  "chart_version": "v1.3.0"
 }

--- a/applications/dir/dev/values.yaml
+++ b/applications/dir/dev/values.yaml
@@ -5,7 +5,7 @@ apiserver:
 
   image:
     repository: ghcr.io/agntcy/dir-apiserver
-    tag: v1.2.0
+    tag: v1.3.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   
@@ -147,8 +147,11 @@ apiserver:
       # For Kind: internal cluster address
       directory_api_address: dir-dir-dev-argoapp-apiserver.dir-dev-dir.svc.cluster.local:8888
 
-      # Nodes to use for bootstrapping of the DHT
-      # For single-node Kind: can be left empty
+      # Nodes to use for bootstrapping of the DHT.
+      # As of dir v1.3.0, the Helm chart provides a public testbed bootstrap
+      # address by default. Leave this unset unless you need to override it.
+      # Current default:
+      # - /dns4/prod.routing.ads.outshift.io/tcp/5555/p2p/12D3KooWLf9p3cedc86xGQBaqak6rAFmQk1HxKAK1yh7umHE3amu
       # bootstrap_peers:
       #   - /ip4/1.1.1.1/tcp/1
       #   - /ip4/1.1.1.1/tcp/2
@@ -204,228 +207,7 @@ apiserver:
   # Reconciler configuration
   reconciler:
     image:
-      tag: v1.2.0
-
-  # ============================================================================
-  # OPTIONAL OIDC AUTHENTICATION ADD-ON (Envoy + ext-authz)
-  # ============================================================================
-  # This add-on solves the common "remote dirctl" problem for users running the
-  # CLI or SDKs outside the cluster. Instead of exposing the Directory API
-  # directly, you place Envoy in front of it:
-  #
-  #   remote client -> OIDC provider -> Envoy jwt_authn -> ext-authz -> Directory
-  #
-  # Use this add-on when you want:
-  # - browser or CLI login through Dex-issued OIDC tokens
-  # - GitHub Actions access through GitHub OIDC tokens
-  # - claim-based role mapping before the request reaches Directory
-  #
-  # Keep this section disabled by default. The existing x509/SPIFFE-based
-  # apiserver authentication still applies to in-cluster and workload traffic.
-  # When enabled, Envoy validates user or workflow JWTs, and ext-authz maps
-  # claims to roles and allowed gRPC methods.
-  # ============================================================================
-  envoyAuthz:
-    enabled: false
-
-  envoy-authz:
-    envoy:
-      # Run more than one Envoy replica for public or shared environments.
-      replicaCount: 2
-
-      # Requests first terminate at Envoy, then Envoy forwards only authorized
-      # gRPC calls to the internal Directory apiserver Service.
-      # This must stay on the internal Kubernetes Service DNS name, not the
-      # public gateway hostname exposed through ingress.
-      backend:
-        address: "dir-dir-dev-argoapp-apiserver.dir-dev-dir.svc.cluster.local"
-        port: 8888
-        timeout: 30s
-
-      # JWT validation at the edge. Enable only the providers you actually use.
-      oidc:
-        dex:
-          # Enable this when you deploy Dex for human or device-flow logins.
-          # Keep these values aligned with applications/dex/dev/values.yaml.
-          enabled: true
-          # Must match dex.config.issuer.
-          issuer: "https://dex.example.com"
-          # Dex publishes signing keys at /keys.
-          jwksUri: "https://dex.example.com/keys"
-          # Override only if the TLS SNI/Host header must differ from issuer.
-          jwksHost: "dex.example.com"
-        github:
-          # Enable this only when GitHub Actions or other GitHub OIDC-based
-          # automation should call Directory directly.
-          enabled: true
-          issuer: "https://token.actions.githubusercontent.com"
-          jwksUri: "https://token.actions.githubusercontent.com/.well-known/jwks"
-          jwksHost: "token.actions.githubusercontent.com"
-          # Optionally require one or more audience values on workflow tokens.
-          # audiences:
-          #   - "dir"
-        # JWKS fetch timeout and cache duration for the Envoy jwt_authn filter.
-        jwksTimeout: 5s
-        jwksCacheSeconds: 300
-
-      spiffe:
-        # Keep SPIFFE enabled so Envoy authenticates to Directory over mTLS.
-        enabled: true
-        trustDomain: example.org
-        className: dir-spire
-
-      # Optional image override if you need to pin a custom Envoy build.
-      # image:
-      #   repository: envoyproxy/envoy
-      #   tag: distroless-v1.37-latest
-      #   pullPolicy: IfNotPresent
-
-      # Optional service or resource tuning for public ingress deployments.
-      # service:
-      #   type: ClusterIP
-      #   port: 8080
-      #   annotations: {}
-      # resources:
-      #   requests:
-      #     cpu: 100m
-      #     memory: 128Mi
-      #   limits:
-      #     cpu: 500m
-      #     memory: 512Mi
-
-    authServer:
-      # ext-authz is a separate gRPC service that makes the allow/deny decision
-      # after Envoy validates the JWT and forwards selected claims.
-      replicaCount: 2
-
-      # Keep the authz image on the same release line as Directory unless you
-      # are intentionally testing a custom authz build.
-      image:
-        repository: ghcr.io/agntcy/envoy-authz
-        tag: v1.2.0
-        pullPolicy: IfNotPresent
-
-      # Optional resource tuning for heavier public traffic.
-      # resources:
-      #   requests:
-      #     cpu: 100m
-      #     memory: 128Mi
-      #   limits:
-      #     cpu: 500m
-      #     memory: 512Mi
-
-      oidc:
-        claims:
-          # "sub" is the safest generic default. Switch to
-          # "preferred_username" if your IdP guarantees that claim.
-          userID: "sub"
-          emailPath: "email"
-
-        # Map known issuers to principal types. This is how ext-authz decides
-        # whether a token represents a human user, service client, or GitHub
-        # workflow principal.
-        # Example:
-        # issuers:
-        #   - provider: "https://dex.example.com"
-        #     principalType: "user"
-        #   - provider: "https://token.actions.githubusercontent.com"
-        #     principalType: "github"
-        # Add one entry per issuer you expect Envoy to accept above.
-        issuers: []
-
-        principalType:
-          # auto   -> infer from claims
-          # user   -> treat tokens as human users
-          # client -> treat tokens as service principals
-          # github -> treat tokens as GitHub workflow principals
-          mode: "auto"
-          machineIdentityClaim: "client_id"
-          machineSubPattern: ""
-
-        # Explicitly block individual principals if needed.
-        userDenyList: []
-
-        # Requests to these paths bypass role checks in ext-authz.
-        publicPaths:
-          - "/healthz"
-          - "/grpc.reflection"
-
-        # Roles map OIDC-derived principals to allowed gRPC methods.
-        # Principal examples:
-        # - user:https://dex.example.com:alice
-        # - client:https://dex.example.com:dirctl-service
-        # - ghwf:repo:agntcy/dir:workflow:import-records.yaml:ref:refs/heads/main
-        # - ghwf:repo:your-org/your-repo:workflow:import-records.yaml:ref:refs/heads/main
-        # - ghwf:repo:your-org/your-repo:workflow:deploy.yml:ref:refs/tags/v1.2.0
-        #
-        # Workflow principal format:
-        # ghwf:repo:<owner>/<repo>:workflow:<workflow-file>:ref:<git-ref>
-        #
-        # Common git-ref examples:
-        # - refs/heads/main
-        # - refs/heads/release/*
-        # - refs/tags/v1.2.0
-        roles:
-          admin:
-            allowedMethods: ["*"]
-            users: []
-            clients: []
-            githubWorkflows: []
-
-          viewer:
-            allowedMethods:
-              - "/agntcy.dir.store.v1.StoreService/Pull"
-              - "/agntcy.dir.store.v1.StoreService/Lookup"
-              - "/agntcy.dir.store.v1.StoreService/PullReferrer"
-              - "/agntcy.dir.search.v1.SearchService/SearchCIDs"
-              - "/agntcy.dir.search.v1.SearchService/SearchRecords"
-            users: []
-            clients: []
-            githubWorkflows: []
-
-          ci-writer:
-            allowedMethods:
-              - "/agntcy.dir.store.v1.StoreService/Push"
-              - "/agntcy.dir.store.v1.StoreService/PushReferrer"
-              - "/agntcy.dir.store.v1.StoreService/Pull"
-              - "/agntcy.dir.search.v1.SearchService/SearchCIDs"
-              - "/agntcy.dir.search.v1.SearchService/SearchRecords"
-            users: []
-            clients: []
-            # Replace [] with explicit workflow principals when CI should write to
-            # the Directory through GitHub OIDC tokens.
-            githubWorkflows:
-              # Example: allow the main branch import workflow in a single repo.
-              # - "ghwf:repo:your-org/your-repo:workflow:import-records.yaml:ref:refs/heads/main"
-              #
-              # Example: allow any branch for a dedicated OIDC test workflow.
-              # - "ghwf:repo:your-org/your-repo:workflow:oidc-test.yml:ref:refs/heads/*"
-              #
-              # Example: allow release tags for a deployment workflow.
-              # - "ghwf:repo:your-org/your-repo:workflow:deploy.yml:ref:refs/tags/v*"
-
-    ingress:
-      # Expose Envoy through a gRPC-capable ingress only when you want remote
-      # users or automation to reach Directory from outside the cluster.
-      # This is the hostname that remote dirctl or SDK clients will target.
-      enabled: false
-      className: nginx
-      host: "" # e.g. gateway.example.com
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt
-        external-dns.alpha.kubernetes.io/hostname: ""
-        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-        nginx.ingress.kubernetes.io/grpc-backend: "true"
-        # Optional rate limiting for public exposure.
-        # nginx.ingress.kubernetes.io/limit-rps: "100"
-        # nginx.ingress.kubernetes.io/limit-rpm: "6000"
-        # nginx.ingress.kubernetes.io/limit-connections: "100"
-        # nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
-        # Some ingress controllers require an explicit gRPC service annotation.
-        # nginx.org/grpc-services: "dir-dir-dev-argoapp-envoy-authz-envoy"
-      tls:
-        enabled: true
-        secretName: ""
+      tag: v1.3.0
 
   # PostgreSQL subchart configuration
   # Deploys PostgreSQL alongside the apiserver

--- a/applications/oidc-gateway/dev/config.json
+++ b/applications/oidc-gateway/dev/config.json
@@ -1,0 +1,5 @@
+{
+  "chart_repo": "ghcr.io",
+  "chart_name": "agntcy/oidc-gateway/helm-charts/oidc-gateway",
+  "chart_version": "v0.1.1"
+}

--- a/applications/oidc-gateway/dev/config.json
+++ b/applications/oidc-gateway/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "ghcr.io",
   "chart_name": "agntcy/oidc-gateway/helm-charts/oidc-gateway",
-  "chart_version": "v0.1.1"
+  "chart_version": "v1.0.0"
 }

--- a/applications/oidc-gateway/dev/values.yaml
+++ b/applications/oidc-gateway/dev/values.yaml
@@ -1,0 +1,173 @@
+# Standalone OIDC Gateway example for dev/staging
+#
+# This chart is deployed separately from `dir` and sits in front of the
+# internal Directory gRPC Service:
+#
+#   remote client -> OIDC provider -> Envoy jwt_authn -> ext_authz -> Directory
+#
+# Use this gateway when you want:
+# - remote `dirctl` access from outside the cluster
+# - browser/device-flow login backed by Dex
+# - GitHub Actions or other external automation to call Directory with OIDC tokens
+#
+# Keep it out of the deployment if you only need in-cluster SPIFFE-based access.
+
+envoy:
+  # Run more than one Envoy replica for shared or public environments.
+  replicaCount: 2
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+  backend:
+    # Point Envoy at the internal Directory Service, not the public gateway host.
+    address: "dir-dir-dev-argoapp-apiserver.dir-dev-dir.svc.cluster.local"
+    port: 8888
+    # Default Envoy route timeout for normal Directory RPCs.
+    # This is an overall timeout on the Envoy -> apiserver hop.
+    timeout: 30s
+    # Preserve the long-lived event stream route.
+    streamingPath: "/agntcy.dir.events.v1.EventService/Listen"
+    # 0s disables the Envoy route timeout for that stream, but any tighter
+    # ingress timeout can still terminate the request first.
+    listenRouteTimeout: 0s
+
+  oidc:
+    # JWT validation at the edge. Add one issuer entry per human/user IdP.
+    issuers:
+      - name: dex
+        enabled: true
+        # Keep these values aligned with applications/dex/dev/values.yaml.
+        issuer: "https://dex.example.com"
+        jwksUri: "https://dex.example.com/keys"
+        jwksHost: "dex.example.com"
+    github:
+      # Enable this when GitHub Actions or other GitHub OIDC-based automation
+      # should call Directory directly.
+      enabled: true
+      issuer: "https://token.actions.githubusercontent.com"
+      jwksUri: "https://token.actions.githubusercontent.com/.well-known/jwks"
+      jwksHost: "token.actions.githubusercontent.com"
+      # Optionally require one or more audience values on workflow tokens.
+      audiences:
+        - "dir"
+    # JWKS fetch timeout and cache duration for Envoy's jwt_authn filter.
+    jwksTimeout: 5s
+    jwksCacheSeconds: 300
+
+  spiffe:
+    # Keep SPIFFE enabled so Envoy authenticates to Directory over mTLS.
+    enabled: true
+    trustDomain: example.org
+    className: dir-spire
+
+authServer:
+  # ext_authz is a separate gRPC service that makes the allow/deny decision
+  # after Envoy validates the JWT and forwards selected claims.
+  replicaCount: 2
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  image:
+    repository: ghcr.io/agntcy/oidc-gateway
+    tag: v0.1.1
+    pullPolicy: IfNotPresent
+
+  config:
+    # The authz server reads a rendered config file from /etc/oidc-gateway/config.yaml.
+    listenAddress: ":9002"
+    logLevel: info
+
+  oidc:
+    claims:
+      # "sub" is the safest generic default.
+      # Switch to preferred_username if your IdP guarantees it consistently.
+      userID: "sub"
+      emailPath: "email"
+    issuers:
+      # Map known issuers to principal types. This is how ext_authz decides
+      # whether a token represents a human user, service client, or GitHub
+      # workflow principal.
+      - provider: "https://dex.example.com"
+        principalType: "user"
+      - provider: "https://token.actions.githubusercontent.com"
+        principalType: "github"
+    principalType:
+      # auto   -> infer from claims
+      # user   -> treat tokens as human users
+      # client -> treat tokens as service principals
+      # github -> treat tokens as GitHub workflow principals
+      mode: "auto"
+      machineIdentityClaim: "client_id"
+      machineSubPattern: ""
+    # Explicitly block individual principals if needed.
+    userDenyList: []
+    publicPaths:
+      - "/healthz"
+      - "/grpc.reflection"
+    roles:
+      # Roles map OIDC-derived principals to allowed gRPC methods.
+      # Principal examples:
+      # - user:https://dex.example.com:alice
+      # - client:https://dex.example.com:dirctl-service
+      # - ghwf:repo:your-org/your-repo:workflow:import-records.yaml:ref:refs/heads/main
+      admin:
+        allowedMethods: ["*"]
+        users: []
+        clients: []
+        githubWorkflows: []
+      viewer:
+        allowedMethods:
+          - "/agntcy.dir.store.v1.StoreService/Pull"
+          - "/agntcy.dir.store.v1.StoreService/Lookup"
+          - "/agntcy.dir.store.v1.StoreService/PullReferrer"
+          - "/agntcy.dir.search.v1.SearchService/SearchCIDs"
+          - "/agntcy.dir.search.v1.SearchService/SearchRecords"
+        users: []
+        clients: []
+        githubWorkflows: []
+      ci-writer:
+        allowedMethods:
+          - "/agntcy.dir.store.v1.StoreService/Push"
+          - "/agntcy.dir.store.v1.StoreService/PushReferrer"
+          - "/agntcy.dir.store.v1.StoreService/Pull"
+          - "/agntcy.dir.search.v1.SearchService/SearchCIDs"
+          - "/agntcy.dir.search.v1.SearchService/SearchRecords"
+        users: []
+        clients: []
+        # Replace [] with explicit workflow principals when CI should write to
+        # the Directory through GitHub OIDC tokens.
+        githubWorkflows: []
+
+ingress:
+  # Expose Envoy through a gRPC-capable ingress only when you want remote
+  # users or automation to reach Directory from outside the cluster.
+  enabled: false
+  className: nginx
+  host: "" # e.g. gateway.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    external-dns.alpha.kubernetes.io/hostname: ""
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    nginx.ingress.kubernetes.io/grpc-backend: "true"
+    # Optional rate limiting for public exposure.
+    # nginx.ingress.kubernetes.io/limit-rps: "100"
+    # nginx.ingress.kubernetes.io/limit-rpm: "6000"
+    # nginx.ingress.kubernetes.io/limit-connections: "100"
+    # nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
+    # Some ingress controllers require the rendered Envoy service name explicitly.
+    # nginx.org/grpc-services: "oidc-gateway-dir-dev-argoapp-envoy"
+  tls:
+    enabled: true
+    secretName: ""

--- a/applications/oidc-gateway/dev/values.yaml
+++ b/applications/oidc-gateway/dev/values.yaml
@@ -3,7 +3,7 @@
 # This chart is deployed separately from `dir` and sits in front of the
 # internal Directory gRPC Service:
 #
-#   remote client -> OIDC provider -> Envoy jwt_authn -> ext_authz -> Directory
+#   remote client -> OIDC/SPIFFE identity -> Envoy -> ext_authz -> Directory
 #
 # Use this gateway when you want:
 # - remote `dirctl` access from outside the cluster
@@ -38,7 +38,9 @@ envoy:
     listenRouteTimeout: 0s
 
   oidc:
-    # JWT validation at the edge. Add one issuer entry per human/user IdP.
+    # Envoy jwt_authn configuration.
+    # This validates bearer JWTs at the edge and forwards verified payloads to ext_authz.
+    # Keep this separate from authServer.oidc, which maps verified identities to roles.
     issuers:
       - name: dex
         enabled: true
@@ -81,7 +83,7 @@ authServer:
 
   image:
     repository: ghcr.io/agntcy/oidc-gateway
-    tag: v0.1.1
+    tag: v1.0.0
     pullPolicy: IfNotPresent
 
   config:
@@ -90,43 +92,42 @@ authServer:
     logLevel: info
 
   oidc:
+    # ext_authz authorization configuration.
+    # This consumes the identities validated by Envoy and applies canonical-principal RBAC.
+    # Keep issuer providers aligned with envoy.oidc issuers above.
     claims:
       # "sub" is the safest generic default.
       # Switch to preferred_username if your IdP guarantees it consistently.
-      userID: "sub"
-      emailPath: "email"
+      principalClaim: "sub"
+      emailClaimPath: "email"
+    headers:
+      # ext_authz forwards this canonical principal header to Directory.
+      # Envoy strips client-supplied values for the same header.
+      authPrincipal: "x-auth-principal"
     issuers:
-      # Map known issuers to principal types. This is how ext_authz decides
-      # whether a token represents a human user, service client, or GitHub
-      # workflow principal.
-      - provider: "https://dex.example.com"
-        principalType: "user"
-      - provider: "https://token.actions.githubusercontent.com"
-        principalType: "github"
-    principalType:
-      # auto   -> infer from claims
-      # user   -> treat tokens as human users
-      # client -> treat tokens as service principals
-      # github -> treat tokens as GitHub workflow principals
-      mode: "auto"
-      machineIdentityClaim: "client_id"
-      machineSubPattern: ""
+      # Map known issuers to stable provider keys used in canonical principals.
+      # OIDC principals become oidc:<providerKey>:<claim-value>.
+      - providerKey: "dex"
+        provider: "https://dex.example.com"
+        authFamily: "oidc"
+      - providerKey: "github"
+        provider: "https://token.actions.githubusercontent.com"
+        authFamily: "oidc"
     # Explicitly block individual principals if needed.
-    userDenyList: []
+    denyList: []
     publicPaths:
       - "/healthz"
       - "/grpc.reflection"
     roles:
-      # Roles map OIDC-derived principals to allowed gRPC methods.
+      # Roles map canonical principals to allowed gRPC methods.
       # Principal examples:
-      # - user:https://dex.example.com:alice
-      # - client:https://dex.example.com:dirctl-service
-      # - ghwf:repo:your-org/your-repo:workflow:import-records.yaml:ref:refs/heads/main
+      # - oidc:dex:alice
+      # - oidc:dex:dirctl-service
+      # - oidc:github:repo:your-org/your-repo:workflow:import-records.yaml:ref:refs/heads/main
+      # - spiffe:spiffe://example.org/ns/default/sa/workload
       admin:
         allowedMethods: ["*"]
-        users: []
-        clients: []
-        githubWorkflows: []
+        principals: []
       viewer:
         allowedMethods:
           - "/agntcy.dir.store.v1.StoreService/Pull"
@@ -134,9 +135,7 @@ authServer:
           - "/agntcy.dir.store.v1.StoreService/PullReferrer"
           - "/agntcy.dir.search.v1.SearchService/SearchCIDs"
           - "/agntcy.dir.search.v1.SearchService/SearchRecords"
-        users: []
-        clients: []
-        githubWorkflows: []
+        principals: []
       ci-writer:
         allowedMethods:
           - "/agntcy.dir.store.v1.StoreService/Push"
@@ -144,11 +143,9 @@ authServer:
           - "/agntcy.dir.store.v1.StoreService/Pull"
           - "/agntcy.dir.search.v1.SearchService/SearchCIDs"
           - "/agntcy.dir.search.v1.SearchService/SearchRecords"
-        users: []
-        clients: []
         # Replace [] with explicit workflow principals when CI should write to
         # the Directory through GitHub OIDC tokens.
-        githubWorkflows: []
+        principals: []
 
 ingress:
   # Expose Envoy through a gRPC-capable ingress only when you want remote

--- a/applicationsets/dir/dev/applicationset.yaml
+++ b/applicationsets/dir/dev/applicationset.yaml
@@ -27,6 +27,9 @@ spec:
                 - appName: dir
                   namespace: dir-dev-dir
                   syncWave: "2"
+                - appName: oidc-gateway
+                  namespace: dir-dev-oidc-gateway
+                  syncWave: "3"
           # Get cluster config to set the cluster address
           - matrix:
               generators:
@@ -37,6 +40,7 @@ spec:
                       - appName: spire
                       - appName: dex
                       - appName: dir
+                      - appName: oidc-gateway
                 - git:
                     repoURL: "https://github.com/agntcy/dir-staging"
                     revision: main
@@ -52,6 +56,7 @@ spec:
                       - appName: spire
                       - appName: dex
                       - appName: dir
+                      - appName: oidc-gateway
                 - git:
                     repoURL: "https://github.com/agntcy/dir-staging"
                     revision: main


### PR DESCRIPTION
## Summary

This PR updates `dir-staging` to match the current public deployment model for Directory `v1.3.0` and `oidc-gateway` `v1.0.0`.

### What changed

- Remove the legacy embedded `envoy-authz` / `envoyAuthz` configuration from the public `dir` staging values example.
- Bump the public `dir` staging example to `v1.3.0`:
  - `applications/dir/dev/config.json`
  - `applications/dir/dev/values.yaml`
- Add a standalone public `oidc-gateway` staging application example:
  - `applications/oidc-gateway/dev/config.json`
  - `applications/oidc-gateway/dev/values.yaml`
- Bump the standalone `oidc-gateway` example to `v1.0.0`.
- Migrate the `oidc-gateway` authz values to the v1.0.0 canonical principal model:
  - `principalClaim` / `emailClaimPath`
  - `headers.authPrincipal`
  - issuer `providerKey` / `authFamily`
  - role `principals`
- Update the staging `ApplicationSet` example so `oidc-gateway` is deployed as its own app after `dir`.
- Rewrite the README OIDC/SPIFFE gateway section to describe `oidc-gateway` as a separate deployment in front of `dir`, with links only to public repos.
- Update Dex example comments so they reference the standalone `oidc-gateway` values layout instead of the removed embedded gateway block.
- Add `oidc-gateway` to the staging vulnerability-scan chart list in `Taskfile.yml`.
- Update the staging `dir` values comments to reflect the `dir` `v1.3.0` default DHT bootstrap address behavior, including the concrete current public testbed bootstrap peer.

### Why

The public `dir` chart no longer embeds `oidc-gateway` as a subchart, so the old staging examples were describing a deployment model that current `dir` no longer supports. This PR makes `dir-staging` consistent with the public split architecture:

- `dir` as one application
- `oidc-gateway` as a separate application
- public references only to `agntcy/dir` and `agntcy/oidc-gateway`

It also updates the standalone gateway example to the `oidc-gateway` v1.0.0 auth model, where Envoy validates JWTs and ext_authz maps verified identities to canonical principals such as `oidc:dex:alice`, `oidc:github:repo:...`, and `spiffe:spiffe://...`.

## Validation

- Rendered the public `dir` chart with the updated staging `applications/dir/dev/values.yaml`
  - confirmed the chart renders
  - confirmed no embedded `oidc-gateway` manifests are produced
  - confirmed the `dir` image example is `v1.3.0`
- Linted the public `oidc-gateway` chart against the staging `applications/oidc-gateway/dev/values.yaml`
- Rendered the public `oidc-gateway` chart with the updated staging values and verified:
  - backend address points to the internal `dir` Service
  - the long-lived `EventService/Listen` route is preserved
  - the rendered Envoy service-name example used by ingress annotations is present
  - `oidc-gateway` is pinned to `v1.0.0`
  - authz config renders with `principalClaim`, `emailClaimPath`, `headers.authPrincipal`, `providerKey`, and `principals`
- Searched `dir-staging` for stale public-facing references and removed:
  - `envoy-authz`
  - `envoyAuthz`
  - `agntcy/dir/install/charts/envoy-authz/values.yaml`
  - `v1.2.0` version references related to the old examples
  - oidc-gateway `v0.1.1` references and legacy authz keys
- Checked edited files for linter issues

## Public references

- `dir` chart values: `agntcy/dir/install/charts/dir/values.yaml`
- `oidc-gateway` chart values: `agntcy/oidc-gateway/install/charts/oidc-gateway/values.yaml`
- `oidc-gateway` repo: `https://github.com/agntcy/oidc-gateway`