### PR TITLE
fix(security): remediate dev image scanning findings

### DIFF
--- a/applications/dir/dev/values.yaml
+++ b/applications/dir/dev/values.yaml
@@ -215,7 +215,8 @@ apiserver:
   postgresql:
     enabled: true
     image:
-      tag: "latest@sha256:621359194c6a0f0fd502c1996f40f539c3e5f2da43401b6d52ee5614722b7cba"
+      tag: "latest"
+      digest: "sha256:ac855a024049fc14d6b73e38ae3b53cf2d93ae69bf7c6174eda550a5de6f5227"
     auth:
       username: "dir"
       password: "dir"
@@ -265,6 +266,9 @@ apiserver:
 
   # Zot registry configuration (subchart)
   zot:
+    image:
+      tag: v2.1.17
+
     # Resources: use chart default for Kind (allows flexible scheduling)
     resources: {}
 

--- a/applications/spire/dev/values.yaml
+++ b/applications/spire/dev/values.yaml
@@ -19,3 +19,9 @@ spire-server:
 
   controllerManager:
     className: dir-spire
+
+# This dev environment uses X.509 SPIFFE identities plus Dex/GitHub OIDC.
+# Disable the SPIRE OIDC discovery provider until upstream ships a helper image
+# without the currently open high/critical Trivy findings.
+spiffe-oidc-discovery-provider:
+  enabled: false


### PR DESCRIPTION
## Summary
- bump the DIR dev Zot image to v2.1.17
- update the DIR dev Bitnami PostgreSQL pin to the current clean upstream digest
- disable the SPIRE OIDC discovery provider in dev to remove the vulnerable spiffe-helper image from the scan surface

## Validation
- rendered the DIR chart and verified it resolves to `ghcr.io/project-zot/zot:v2.1.17`
- rendered the DIR chart and verified it resolves to `docker.io/bitnami/postgresql@sha256:ac855a024049fc14d6b73e38ae3b53cf2d93ae69bf7c6174eda550a5de6f5227`
- rendered the SPIRE chart and verified `ghcr.io/spiffe/spiffe-helper:0.11.0` is no longer included