### PR TITLE
chore(deps): pin spire-csi-driver images and switch dex to the distroless tag

### DIFF
--- a/applications/dex/dev/values.yaml
+++ b/applications/dex/dev/values.yaml
@@ -16,7 +16,7 @@
 replicaCount: 1
 
 image:
-  tag: v2.45.1
+  tag: v2.45.1-distroless
 
 config:
   # Public URL where Dex is exposed (must match ingress/DNS)

--- a/applications/spire/dev/values.yaml
+++ b/applications/spire/dev/values.yaml
@@ -25,3 +25,10 @@ spire-server:
 # without the currently open high/critical Trivy findings.
 spiffe-oidc-discovery-provider:
   enabled: false
+
+spiffe-csi-driver:
+  image:
+    tag: "0.2.9"
+  nodeDriverRegistrar:
+    image:
+      tag: "v2.17.0"


### PR DESCRIPTION
Locks down the dev-environment helm values for the SPIRE and Dex deployments. The `spiffe-csi-driver` subchart was previously using whatever image tags it shipped with by default, and Dex was running the standard image; both now use explicit, hardened tags so deployments are reproducible and pick up the distroless Dex variant.

- Pins `spiffe-csi-driver.image.tag` to `0.2.9` and `spiffe-csi-driver.nodeDriverRegistrar.image.tag` to `v2.17.0` in `applications/spire/dev/values.yaml`.
- Bumps Dex from `v2.45.1` to `v2.45.1-distroless` in `applications/dex/dev/values.yaml` to reduce the container attack surface.