### PR TITLE
feat: follow up the testbed changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Federation requires configuring SPIRE to exchange trust bundles with other Direc
 2. **Create Your Federation File**
    - Describes how others can connect to your SPIRE federation endpoint
    - Template: `onboarding/federation/.federation.web.template.yaml` (or `.federation.spiffe.template.yaml`)
-   - Example: See `onboarding/federation/prod.ads.outshift.io.yaml` for reference
+   - Example: See `onboarding/federation/spire.ads.outshift.io.yaml` for reference
 
 3. **Submit Your Federation File**
    - Fork this repository
@@ -151,7 +151,7 @@ Federation requires configuring SPIRE to exchange trust bundles with other Direc
    - Submit a Pull Request
 
 4. **Deploy Directory's Federation File**
-   - After approval, deploy `onboarding/federation/prod.ads.outshift.io.yaml` to your cluster
+   - After approval, deploy `onboarding/federation/spire.ads.outshift.io.yaml` to your cluster
    - Run `task gen:dir` to regenerate `applications/dir/gen.values.yaml`
    - ArgoCD will automatically sync the federation configuration
    - This tells your SPIRE how to connect to the Directory network

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,7 +70,7 @@ tasks:
     vars:
       DEST_VALUES: "{{ .ROOT_DIR }}/applications/dir/gen.values.yaml"
       # Glob pattern matches visible .yaml files only (excludes hidden .*.yaml templates)
-      # Matches: dev.ads.outshift.io.yaml, prod.ads.outshift.io.yaml, etc.
+      # Matches: dev.ads.outshift.io.yaml, spire.ads.outshift.io.yaml, etc.
       # Excludes: .federation.web.template.yaml, .federation.spiffe.template.yaml
       FEDERATION_SOURCE: "{{ .ROOT_DIR }}/onboarding/federation/*.yaml"
     cmds:

--- a/applications/dir/dev/values.yaml
+++ b/applications/dir/dev/values.yaml
@@ -151,7 +151,7 @@ apiserver:
       # As of dir v1.3.0, the Helm chart provides a public testbed bootstrap
       # address by default. Leave this unset unless you need to override it.
       # Current default:
-      # - /dns4/prod.routing.ads.outshift.io/tcp/5555/p2p/12D3KooWLf9p3cedc86xGQBaqak6rAFmQk1HxKAK1yh7umHE3amu
+      # - /dns4/routing.ads.outshift.io/tcp/5555/p2p/12D3KooWLf9p3cedc86xGQBaqak6rAFmQk1HxKAK1yh7umHE3amu
       # bootstrap_peers:
       #   - /ip4/1.1.1.1/tcp/1
       #   - /ip4/1.1.1.1/tcp/2

--- a/docs/federation-troubleshooting.md
+++ b/docs/federation-troubleshooting.md
@@ -115,10 +115,10 @@ echo $DIRECTORY_CLIENT_SERVER_ADDRESS $DIRECTORY_CLIENT_SPIFFE_SOCKET_PATH
 
 ```bash
 # Verify trust bundle exchange
-spire-server federation show --trustDomain prod.ads.outshift.io
+spire-server federation show --trustDomain spire.ads.outshift.io
 
 # Test bundle endpoint
-curl https://prod.spire.ads.outshift.io/
+curl https://spire.ads.outshift.io/
 ```
 
 ### Common Errors

--- a/docs/federation-troubleshooting.md
+++ b/docs/federation-troubleshooting.md
@@ -105,7 +105,7 @@ This page covers operational best practices and troubleshooting for Directory fe
 spire-agent api fetch x509-svid
 
 # Verify network connectivity
-curl -v https://prod.api.ads.outshift.io
+curl -v https://ads.outshift.io
 
 # Verify env vars are set
 echo $DIRECTORY_CLIENT_SERVER_ADDRESS $DIRECTORY_CLIENT_SPIFFE_SOCKET_PATH

--- a/docs/partner-prod-federation.md
+++ b/docs/partner-prod-federation.md
@@ -1,8 +1,8 @@
 # Running a Federated Directory Instance
 
-This guide explains how to federate your Directory instance (`partner.io`) with the public production Directory at `prod.ads.outshift.io`. The prod instance uses the `https_web` bundle endpoint profile (Let's Encrypt, standard HTTPS). Your instance must use `https_web` as well for compatibility.
+This guide explains how to federate your Directory instance (`partner.io`) with the public production Directory at `spire.ads.outshift.io`. The prod instance uses the `https_web` bundle endpoint profile (Let's Encrypt, standard HTTPS). Your instance must use `https_web` as well for compatibility.
 
-Partnering with the Production Directory involves two trust domains. `partner.io` is your instance's trust domain and `prod.ads.outshift.io` is the production Directory's trust domain.
+Partnering with the Production Directory involves two trust domains. `partner.io` is your instance's trust domain and `spire.ads.outshift.io` is the production Directory's trust domain.
 
 Assumptions:
 
@@ -20,7 +20,7 @@ Assumptions:
 
 1. Deploy SPIRE with https_web federation
 
-    SPIRE must use the `https_web` profile so it can fetch prod's bundle over standard HTTPS (Let's Encrypt). The prod federation endpoint is `https://prod.spire.ads.outshift.io`.
+    SPIRE must use the `https_web` profile so it can fetch prod's bundle over standard HTTPS (Let's Encrypt). The prod federation endpoint is `https://spire.ads.outshift.io`.
 
     ??? example "Deploy SPIRE with https_web federation"
 
@@ -84,7 +84,7 @@ Assumptions:
                 clusterSPIFFEIDs:
                   default:
                     federatesWith:
-                      - prod.ads.outshift.io
+                      - spire.ads.outshift.io
 
           spiffe-oidc-discovery-provider:
             ingress:
@@ -127,8 +127,8 @@ Assumptions:
             useCSIDriver: true
             federation:
               - className: dir-spire
-                trustDomain: prod.ads.outshift.io
-                bundleEndpointURL: https://prod.spire.ads.outshift.io
+                trustDomain: spire.ads.outshift.io
+                bundleEndpointURL: https://spire.ads.outshift.io
                 bundleEndpointProfile:
                   type: https_web
           config:
@@ -171,7 +171,7 @@ Assumptions:
                 ssl_mode: "disable"
           authz_policies_csv: |
             p,partner.io,*
-            p,prod.ads.outshift.io,*
+            p,spire.ads.outshift.io,*
             p,*,/agntcy.dir.store.v1.StoreService/Pull
             p,*,/agntcy.dir.store.v1.StoreService/PullReferrer
             p,*,/agntcy.dir.store.v1.StoreService/Lookup
@@ -261,10 +261,10 @@ Assumptions:
     ```bash
     # On your cluster – prod's bundle should appear in SPIRE
     kubectl exec -n spire spire-server-0 -c spire-server -- \
-      spire-server bundle list -id spiffe://prod.ads.outshift.io -format spiffe
+      spire-server bundle list -id spiffe://spire.ads.outshift.io -format spiffe
     ```
 
-    The prod's trust bundle is listed. If the bundle is missing, check that `ClusterFederatedTrustDomain` for prod exists and that the SPIRE server can reach `https://prod.spire.ads.outshift.io`.
+    The prod's trust bundle is listed. If the bundle is missing, check that `ClusterFederatedTrustDomain` for prod exists and that the SPIRE server can reach `https://spire.ads.outshift.io`.
 
 4. Contribute to `dir-staging` for prod federation
 

--- a/onboarding/README.md
+++ b/onboarding/README.md
@@ -23,11 +23,12 @@ Federation is required before you can discover or publish agents. The test in st
 
 ## 🌐 Available Endpoints
 
-| Service              | URL                                      | Purpose                                     |
-| -------------------- | ---------------------------------------- | ------------------------------------------- |
-| **Directory API**    | `https://prod.api.ads.outshift.io`       | Main API for agent discovery and management |
-| **SPIRE Federation** | `https://spire.ads.outshift.io`     | SPIRE server for secure identity federation |
-| **Status Dashboard** | `https://prod.status.ads.outshift.io`    | Real-time service status and monitoring     |
+| Service              | URL                              | Purpose                                                                 |
+| -------------------- | -------------------------------- | ----------------------------------------------------------------------- |
+| **Directory API**    | `ads.outshift.io:443`            | Main gRPC API for agent discovery and management (via the OIDC/JWT gateway) |
+| **OIDC Issuer**      | `https://idp.ads.outshift.io`    | OIDC token issuer (Dex) for CLI and human authentication                |
+| **SPIRE Federation** | `https://spire.ads.outshift.io`  | SPIRE bundle endpoint for identity federation (trust domain `spire.ads.outshift.io`) |
+| **OCI Registry**     | `https://store.ads.outshift.io`  | OCI registry storing Directory records (pulled by peers during sync)    |
 
 ## 🎯 Prerequisites
 
@@ -82,7 +83,7 @@ Once federation is complete, test:
 
 ```bash
 dirctl pull bafytest123 \
-  --server-addr prod.api.ads.outshift.io \
+  --server-addr ads.outshift.io:443 \
   --spiffe-socket-path /tmp/spire-agent/public.sock
 # Expected: Error: record not found (proves connection and federation work)
 ```

--- a/onboarding/README.md
+++ b/onboarding/README.md
@@ -26,7 +26,7 @@ Federation is required before you can discover or publish agents. The test in st
 | Service              | URL                                      | Purpose                                     |
 | -------------------- | ---------------------------------------- | ------------------------------------------- |
 | **Directory API**    | `https://prod.api.ads.outshift.io`       | Main API for agent discovery and management |
-| **SPIRE Federation** | `https://prod.spire.ads.outshift.io`     | SPIRE server for secure identity federation |
+| **SPIRE Federation** | `https://spire.ads.outshift.io`     | SPIRE server for secure identity federation |
 | **Status Dashboard** | `https://prod.status.ads.outshift.io`    | Real-time service status and monitoring     |
 
 ## 🎯 Prerequisites
@@ -72,7 +72,7 @@ See [Federation Profiles](https://docs.agntcy.org/dir/federation-profiles/) for 
 
 4. **Configure your SPIRE** to federate with Directory:
    - **If you deploy from this repo:** run `task gen:dir` to regenerate `applications/dir/gen.values.yaml`; ArgoCD will sync.
-   - **If you have a custom deployment:** add Directory's federation config to your SPIRE. Use [federation/prod.ads.outshift.io.yaml](federation/prod.ads.outshift.io.yaml) as reference; add a `ClusterFederatedTrustDomain` (or equivalent) for `prod.ads.outshift.io`.
+   - **If you have a custom deployment:** add Directory's federation config to your SPIRE. Use [federation/spire.ads.outshift.io.yaml](federation/spire.ads.outshift.io.yaml) as reference; add a `ClusterFederatedTrustDomain` (or equivalent) for `spire.ads.outshift.io`.
 
 For full federation setup, [Partner Federation with Prod](https://docs.agntcy.org/dir/partner-prod-federation/) and [Federation Troubleshooting](https://docs.agntcy.org/dir/federation-troubleshooting/).
 

--- a/onboarding/federation/prod.ads.outshift.io.yaml
+++ b/onboarding/federation/prod.ads.outshift.io.yaml
@@ -1,6 +1,0 @@
-className: dir-spire
-trustDomain: prod.ads.outshift.io
-bundleEndpointURL: https://prod.spire.ads.outshift.io
-bundleEndpointProfile:
-  type: https_web
-

--- a/onboarding/federation/spire.ads.outshift.io.yaml
+++ b/onboarding/federation/spire.ads.outshift.io.yaml
@@ -1,0 +1,5 @@
+className: dir-spire
+trustDomain: spire.ads.outshift.io
+bundleEndpointURL: https://spire.ads.outshift.io
+bundleEndpointProfile:
+  type: https_web


### PR DESCRIPTION
# Description

Follow-up to the prod testbed changes. The production Directory's SPIRE trust domain and federation bundle endpoint are being renamed, so the public federation descriptor and onboarding docs in this repo must match what prod actually publishes.

Changes:

- **Rename the prod federation descriptor** `onboarding/federation/prod.ads.outshift.io.yaml` -> `onboarding/federation/spire.ads.outshift.io.yaml`:
  - `trustDomain`: `prod.ads.outshift.io` -> `spire.ads.outshift.io`
  - `bundleEndpointURL`: `https://prod.spire.ads.outshift.io` -> `https://spire.ads.outshift.io`
  - (The filename encodes the trust domain and is matched by `Taskfile.yml`, so the file is renamed rather than edited in place.)
- **Update onboarding docs/READMEs** to the new trust domain, bundle endpoint, and descriptor filename:
  - `README.md` — federation file reference path.
  - `onboarding/README.md` — SPIRE federation endpoint URL, descriptor reference, and trust domain.
  - `docs/partner-prod-federation.md` — prod trust domain, federation endpoint URL, `federatesWith`, `bundleEndpointURL`, authz policy subject, and `bundle list` SPIFFE ID.
  - `docs/federation-troubleshooting.md` — `federation show --trustDomain` and bundle endpoint `curl`.

The new trust domain and its bundle endpoint now share a single self-consistent host (`spire.ads.outshift.io`), replacing the previous `prod.ads.outshift.io` trust domain + `prod.spire.ads.outshift.io` endpoint pair.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

> Breaking: existing federated peers hold a trust bundle bound to `prod.ads.outshift.io` and point at `https://prod.spire.ads.outshift.io`. After prod cuts over, every partner must update `trustDomain`/`bundleEndpointURL` to `spire.ads.outshift.io` and re-bootstrap the bundle. New DNS + Let's Encrypt cert for `spire.ads.outshift.io` must be live before federation works.

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/dir-staging/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
