### PR TITLE
chore: updating filenames and links

### DIFF
--- a/docs/dir-federation-profiles.md
+++ b/docs/dir-federation-profiles.md
@@ -2,7 +2,7 @@
 
 Directory supports two federation bundle profiles for secure trust bundle exchange between SPIRE servers. Each profile implements distinct security models, infrastructure requirements, and operational characteristics. This document provides technical guidance to assist in profile selection and implementation.
 
-For step-by-step federation setup with the public Directory network, see [Running a Federated Directory Instance](partner-prod-federation.md).
+For step-by-step federation setup with the public Directory network, see [Running a Federated Directory Instance](dir-federation-setup.md).
 
 ## Profile Comparison
 

--- a/docs/dir-federation-setup.md
+++ b/docs/dir-federation-setup.md
@@ -292,11 +292,11 @@ Assumptions:
 
 ## Use Cases
 
-See [Features and Usage Scenarios](scenarios.md) for sample applications and workflows.
+See [Features and Usage Scenarios](dir-features-scenarios.md) for sample applications and workflows.
 
 ## Next Steps
 
 - Publish agents: Use `dirctl push` or the SDK to publish records to the public Directory.
-- Deploy your own instance: See [Production Deployment](prod-deployment.md) for AWS EKS and federation.
-- Explore scenarios: [Features and Usage Scenarios](scenarios.md) for build, store, sign, discover, and search workflows.
-- Federation issues: See [Federation Best Practices and Troubleshooting](federation-troubleshooting.md) for operational guidance and common errors.
+- Deploy your own instance: See [Production Deployment](dir-prod-deployment.md) for AWS EKS and federation.
+- Explore scenarios: [Features and Usage Scenarios](dir-features-scenarios.md) for build, store, sign, discover, and search workflows.
+- Federation issues: See [Federation Best Practices and Troubleshooting](dir-federation-troubleshooting.md) for operational guidance and common errors.

--- a/docs/dir-federation-troubleshooting.md
+++ b/docs/dir-federation-troubleshooting.md
@@ -1,6 +1,6 @@
 # Federation Best Practices and Troubleshooting
 
-This page covers operational best practices and troubleshooting for Directory federation. It applies to both [https_web and https_spiffe](federation-profiles.md#profile-comparison) profiles. For profile selection and configuration details, see [Federation Bundle Profiles](federation-profiles.md).
+This page covers operational best practices and troubleshooting for Directory federation. It applies to both [https_web and https_spiffe](dir-federation-profiles.md#profile-comparison) profiles. For profile selection and configuration details, see [Federation Bundle Profiles](dir-federation-profiles.md).
 
 ## Operational Best Practices
 
@@ -205,7 +205,7 @@ kubectl logs -n dir-spire -l app.kubernetes.io/name=server -c spire-server | \
 
 **Root Cause:** Bootstrap bundle is missing, stale, or incorrectly formatted.
 
-**Resolution:** Obtain a fresh bundle from your federation partner, validate it, and update `trustDomainBundle` in your federation resource. See [Bootstrap Bundle Exchange Process](federation-profiles.md#bootstrap-bundle-exchange-process-https_spiffe) for extraction and validation steps:
+**Resolution:** Obtain a fresh bundle from your federation partner, validate it, and update `trustDomainBundle` in your federation resource. See [Bootstrap Bundle Exchange Process](dir-federation-profiles.md#bootstrap-bundle-exchange-process-https_spiffe) for extraction and validation steps:
 
 ```bash
 # Obtain fresh bundle from federation partner


### PR DESCRIPTION
# Description

Updates filenames to align with directory naming conventions and not break when building the docs site.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/dir-staging/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
