### PR TITLE
chore(deps): bump dir to v1.7.0 and refresh dex/spire/oidc-gateway chart versions

### DIFF
--- a/applications/dex/dev/config.json
+++ b/applications/dex/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "https://charts.dexidp.io",
   "chart_name": "dex",
-  "chart_version": "0.24.0"
+  "chart_version": "0.24.1"
 }

--- a/applications/dir/dev/config.json
+++ b/applications/dir/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "ghcr.io",
   "chart_name": "agntcy/dir/helm-charts/dir",
-  "chart_version": "v1.6.1"
+  "chart_version": "v1.6.2"
 }

--- a/applications/dir/dev/config.json
+++ b/applications/dir/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "ghcr.io",
   "chart_name": "agntcy/dir/helm-charts/dir",
-  "chart_version": "v1.5.0"
+  "chart_version": "v1.6.1"
 }

--- a/applications/dir/dev/config.json
+++ b/applications/dir/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "ghcr.io",
   "chart_name": "agntcy/dir/helm-charts/dir",
-  "chart_version": "v1.3.0"
+  "chart_version": "v1.5.0"
 }

--- a/applications/dir/dev/config.json
+++ b/applications/dir/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "ghcr.io",
   "chart_name": "agntcy/dir/helm-charts/dir",
-  "chart_version": "v1.6.2"
+  "chart_version": "v1.7.0"
 }

--- a/applications/dir/dev/values.yaml
+++ b/applications/dir/dev/values.yaml
@@ -5,7 +5,7 @@ apiserver:
 
   image:
     repository: ghcr.io/agntcy/dir-apiserver
-    tag: v1.3.0
+    tag: v1.5.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   
@@ -207,7 +207,7 @@ apiserver:
   # Reconciler configuration
   reconciler:
     image:
-      tag: v1.3.0
+      tag: v1.5.0
 
   # PostgreSQL subchart configuration
   # Deploys PostgreSQL alongside the apiserver

--- a/applications/dir/dev/values.yaml
+++ b/applications/dir/dev/values.yaml
@@ -216,7 +216,7 @@ apiserver:
     enabled: true
     image:
       tag: "latest"
-      digest: "sha256:7651d7f24aad83fe68a222f7f20eded10d325c96ebee285ca5bf8162eddcba64"
+      digest: "sha256:d92a6bbf5184e327301856457e35cefcc32e19158e46a4012929e20daa9c178d"
     auth:
       username: "dir"
       password: "dir"
@@ -267,7 +267,7 @@ apiserver:
   # Zot registry configuration (subchart)
   zot:
     image:
-      tag: v2.1.17
+      tag: v2.1.20
 
     # Resources: use chart default for Kind (allows flexible scheduling)
     resources: {}

--- a/applications/dir/dev/values.yaml
+++ b/applications/dir/dev/values.yaml
@@ -5,7 +5,7 @@ apiserver:
 
   image:
     repository: ghcr.io/agntcy/dir-apiserver
-    tag: v1.6.2
+    tag: v1.7.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   
@@ -207,7 +207,7 @@ apiserver:
   # Reconciler configuration
   reconciler:
     image:
-      tag: v1.6.2
+      tag: v1.7.0
 
   # PostgreSQL subchart configuration
   # Deploys PostgreSQL alongside the apiserver

--- a/applications/dir/dev/values.yaml
+++ b/applications/dir/dev/values.yaml
@@ -5,7 +5,7 @@ apiserver:
 
   image:
     repository: ghcr.io/agntcy/dir-apiserver
-    tag: v1.5.0
+    tag: v1.6.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   
@@ -207,7 +207,7 @@ apiserver:
   # Reconciler configuration
   reconciler:
     image:
-      tag: v1.5.0
+      tag: v1.6.1
 
   # PostgreSQL subchart configuration
   # Deploys PostgreSQL alongside the apiserver

--- a/applications/dir/dev/values.yaml
+++ b/applications/dir/dev/values.yaml
@@ -5,7 +5,7 @@ apiserver:
 
   image:
     repository: ghcr.io/agntcy/dir-apiserver
-    tag: v1.6.1
+    tag: v1.6.2
     pullPolicy: IfNotPresent
     pullSecrets: []
   
@@ -207,7 +207,7 @@ apiserver:
   # Reconciler configuration
   reconciler:
     image:
-      tag: v1.6.1
+      tag: v1.6.2
 
   # PostgreSQL subchart configuration
   # Deploys PostgreSQL alongside the apiserver

--- a/applications/oidc-gateway/dev/config.json
+++ b/applications/oidc-gateway/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "ghcr.io",
   "chart_name": "agntcy/oidc-gateway/helm-charts/oidc-gateway",
-  "chart_version": "v1.1.2"
+  "chart_version": "v1.1.4"
 }

--- a/applications/oidc-gateway/dev/config.json
+++ b/applications/oidc-gateway/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "ghcr.io",
   "chart_name": "agntcy/oidc-gateway/helm-charts/oidc-gateway",
-  "chart_version": "v1.0.0"
+  "chart_version": "v1.1.2"
 }

--- a/applications/oidc-gateway/dev/values.yaml
+++ b/applications/oidc-gateway/dev/values.yaml
@@ -83,7 +83,7 @@ authServer:
 
   image:
     repository: ghcr.io/agntcy/oidc-gateway
-    tag: v1.1.2
+    tag: v1.1.4
     pullPolicy: IfNotPresent
 
   config:

--- a/applications/oidc-gateway/dev/values.yaml
+++ b/applications/oidc-gateway/dev/values.yaml
@@ -83,7 +83,7 @@ authServer:
 
   image:
     repository: ghcr.io/agntcy/oidc-gateway
-    tag: v1.0.0
+    tag: v1.1.2
     pullPolicy: IfNotPresent
 
   config:

--- a/applications/spire-crds/dev/config.json
+++ b/applications/spire-crds/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "https://spiffe.github.io/helm-charts-hardened",
   "chart_name": "spire-crds",
-  "chart_version": "0.5.0"
+  "chart_version": "0.6.0"
 }

--- a/applications/spire/dev/config.json
+++ b/applications/spire/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "https://spiffe.github.io/helm-charts-hardened",
   "chart_name": "spire",
-  "chart_version": "0.28.4"
+  "chart_version": "0.29.0"
 }

--- a/applications/spire/dev/config.json
+++ b/applications/spire/dev/config.json
@@ -1,5 +1,5 @@
 {
   "chart_repo": "https://spiffe.github.io/helm-charts-hardened",
   "chart_name": "spire",
-  "chart_version": "0.29.0"
+  "chart_version": "0.30.0"
 }

--- a/applications/spire/dev/values.yaml
+++ b/applications/spire/dev/values.yaml
@@ -15,14 +15,14 @@ global:
 
 spire-server:
   image:
-    tag: "1.15.0"
+    tag: "1.15.2"
 
   federation:
     enabled: true
 
   controllerManager:
     image:
-      tag: "0.6.4"
+      tag: "0.7.0"
     className: dir-spire
 
 # This dev environment uses X.509 SPIFFE identities plus Dex/GitHub OIDC.
@@ -30,14 +30,14 @@ spire-server:
 # without the currently open high/critical Trivy findings.
 spire-agent:
   image:
-    tag: "1.15.0"
+    tag: "1.15.2"
 
 spiffe-oidc-discovery-provider:
   enabled: false
 
 spiffe-csi-driver:
   image:
-    tag: "0.2.9"
+    tag: "0.2.13"
   nodeDriverRegistrar:
     image:
       tag: "v2.17.0"


### PR DESCRIPTION
Updates the development environment to the latest Directory release and pulls in newer upstream Helm charts for the supporting Dex and SPIRE deployments, keeping the dev applications aligned with current versions.

- Bumps the `dir` chart and `dir-apiserver`/reconciler image tags from `v1.3.0` to `v1.7.0` in `applications/dir/dev`.
- Bumps the `zot` image tag from `v2.1.17` to `v2.1.20` and the `postgresql` image digest to 18.6.0 in `applications/dir/dev/values.yaml`.
- Updates the `oidc-gateway` chart and image versions from `v1.0.0` to `v1.1.4` in `applications/oidc-gateway/dev`.
- Updates the `dex` chart version from `0.24.0` to `0.24.1` in `applications/dex/dev/config.json`.
- Updates the `spire` chart version from `0.28.4` to `0.30.0` in `applications/spire/dev/config.json`.
- Updates the `spire-crds` chart version from `0.5.0` to `0.6.0` in `applications/spire-crds/dev/config.json`.